### PR TITLE
Merge vs Overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Default: `false`
 
 Merge new secrets over old. Existing parameters are overwritten only if present in the new set of secrets.
 
+
+#### overwrite
+Type: `boolean`  
+Default: `false`  
+
+Completely replace the old secrets object with the new one.
+
+
 #### keyId
 Type: `string`  
 Default: Your AWS account's default key.  

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const putSecrets = require('secrets-handler').putSecrets
 putSecrets({
   secrets: { some: 'secrets' },
   path: '/awesome/project',
-  overwrite: true,
+  merge: true,
   awsConfig: { region: 'us-east-1' }
 })
 .then(parameters => {})
@@ -62,11 +62,11 @@ Default: `uuid()`
 Specify a path to be used as a prefix on the parameter names. If none is provided a UUID will be used to prevent parameter name collision.
 
 
-#### overwrite
+#### merge
 Type: `boolean`  
 Default: `false`  
 
-Flag indicating that existing parameters should be overwritten.
+Merge new secrets over old. Existing parameters are overwritten only if present in the new set of secrets.
 
 #### keyId
 Type: `string`  

--- a/bin/putSecrets.js
+++ b/bin/putSecrets.js
@@ -2,7 +2,7 @@
 
 const putSecrets = require('../lib/putSecrets')
 
-const action = (path, { overwrite, keyId }) => {
+const action = (path, { merge, keyId }) => {
   let secretsString = ''
   process.stdin.setEncoding('utf8')
   process.stdin.on('readable', () => {
@@ -11,7 +11,7 @@ const action = (path, { overwrite, keyId }) => {
 
   process.stdin.on('end', () => {
     const secrets = JSON.parse(secretsString)
-    putSecrets({ path, overwrite, keyId, secrets })
+    putSecrets({ path, merge, keyId, secrets })
     .then(result => {
       process.stdout.write(JSON.stringify(result, null, 2))
       process.exit()

--- a/bin/putSecrets.js
+++ b/bin/putSecrets.js
@@ -2,7 +2,7 @@
 
 const putSecrets = require('../lib/putSecrets')
 
-const action = (path, { merge, keyId }) => {
+const action = (path, { merge, overwrite, keyId }) => {
   let secretsString = ''
   process.stdin.setEncoding('utf8')
   process.stdin.on('readable', () => {
@@ -11,7 +11,7 @@ const action = (path, { merge, keyId }) => {
 
   process.stdin.on('end', () => {
     const secrets = JSON.parse(secretsString)
-    putSecrets({ path, merge, keyId, secrets })
+    putSecrets({ path, merge, overwrite, keyId, secrets })
     .then(result => {
       process.stdout.write(JSON.stringify(result, null, 2))
       process.exit()

--- a/bin/secrets-handler.js
+++ b/bin/secrets-handler.js
@@ -18,7 +18,7 @@ commander
 commander
 .command('put <path>')
 .description('Read a secrets object from standard input and store it as individual parameters in AWS SSM.')
-.option('-o, --overwrite', 'Flag indicating that existing parameters should be overwritten.')
+.option('-m, --merge', 'Merge new secrets over old. Existing parameters are overwritten only if present in the new set of secrets.')
 .option('-k, --key-id <keyId>', 'Specify a KMS key to use when encrypting parameters. Defaults to your AWS account\'s default key.')
 .action(putSecrets)
 

--- a/bin/secrets-handler.js
+++ b/bin/secrets-handler.js
@@ -19,6 +19,7 @@ commander
 .command('put <path>')
 .description('Read a secrets object from standard input and store it as individual parameters in AWS SSM.')
 .option('-m, --merge', 'Merge new secrets over old. Existing parameters are overwritten only if present in the new set of secrets.')
+.option('-o, --overwrite', 'Completely replace the old secrets object with the new one.')
 .option('-k, --key-id <keyId>', 'Specify a KMS key to use when encrypting parameters. Defaults to your AWS account\'s default key.')
 .action(putSecrets)
 

--- a/lib/putSecrets.js
+++ b/lib/putSecrets.js
@@ -2,15 +2,24 @@ const cleanPath = require('./cleanPath')
 const assert = require('assert')
 const traverse = require('traverse')
 const aws = require('aws-sdk')
+const deleteSecrets = require('./deleteSecrets')
 
-module.exports = ({ path, merge, secrets, awsConfig, keyId } = {}) => {
+module.exports = ({ path, merge, overwrite, secrets, awsConfig, keyId } = {}) => {
   path = cleanPath(path)
 
   assert.equal(typeof secrets, 'object', 'secrets should be an object')
 
   const ssm = new aws.SSM(awsConfig)
 
-  return Promise.all(traverse(secrets).reduce(function (proms, Value) {
+  function handleOverwrite () {
+    if (overwrite) {
+      return deleteSecrets({ path, awsConfig })
+    }
+    return Promise.resolve()
+  }
+
+  return handleOverwrite()
+  .then(() => Promise.all(traverse(secrets).reduce(function (proms, Value) {
     if (this.isLeaf && Value !== null) {
       Value = Value.toString()
       const Name = `${path}${this.path.join('.')}`
@@ -34,8 +43,8 @@ module.exports = ({ path, merge, secrets, awsConfig, keyId } = {}) => {
   }, []))
   .catch((error) => {
     if (error.code === 'ParameterAlreadyExists') {
-      error.message = `A parameter already exists. To replace it, use the merge option.`
+      error.message = `Matching secrets already exist. To replace them, use the merge or overwrite option.`
     }
     throw error
-  })
+  }))
 }

--- a/lib/putSecrets.js
+++ b/lib/putSecrets.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 const traverse = require('traverse')
 const aws = require('aws-sdk')
 
-module.exports = ({ path, overwrite, secrets, awsConfig, keyId } = {}) => {
+module.exports = ({ path, merge, secrets, awsConfig, keyId } = {}) => {
   path = cleanPath(path)
 
   assert.equal(typeof secrets, 'object', 'secrets should be an object')
@@ -18,7 +18,7 @@ module.exports = ({ path, overwrite, secrets, awsConfig, keyId } = {}) => {
         Name,
         Value,
         Type: 'SecureString',
-        Overwrite: !!overwrite,
+        Overwrite: !!merge,
         KeyId: keyId
       }
       proms.push(
@@ -32,4 +32,10 @@ module.exports = ({ path, overwrite, secrets, awsConfig, keyId } = {}) => {
     }
     return proms
   }, []))
+  .catch((error) => {
+    if (error.code === 'ParameterAlreadyExists') {
+      error.message = `A parameter already exists. To replace it, use the merge option.`
+    }
+    throw error
+  })
 }


### PR DESCRIPTION
Changes the current `overwrite` option to `merge`, which should better represent its behavior.  Adds a revamped `overwrite`, which actually deletes the secrets first then adds the new ones effectively doing a full replace or overwrite.